### PR TITLE
Removed hatchling from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,3 @@ dev = [
     "pytest>=7.0",
     "pytest-mock>=3.11",
 ]
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"


### PR DESCRIPTION
Hatchling caused uv to throw build errors. Removed to resolve/.